### PR TITLE
Implement the Listen mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,39 @@ The following interfaces are provided:
 ```
 org.freedesktop.tuhi1.Manager
 
-   Property: Devices (ao)
+  Property: Devices (ao)
 
-   Array of object paths to known (previously paired, but not necessarily
-   connected) devices.
+      Array of object paths to known (previously paired, but not necessarily
+      connected) devices.
+
+  Property: Listening (b)
+      Indicates whether the daemon is currently listening for device events.
+
+      This property is set to True when a Listen() request initiates the
+      search for device connections. When the Listen() request completes
+      upon timeout, the property is set to False.
+      Read-only
+
+  Method: Listen() -> ()
+      Listen for data from this host. This method starts listening for
+      events on the device for an unspecified timeout. When the timeout
+      expires, a ListenComplete signal is sent indicating success or error.
+
+      When a compatible device appears (button pressed), the daemon connects
+      to it and downloads all drawings from the device.
+      If successfull, the drawings are deleted from the device.
+      The data is held by the daemon in non-persistent storage until the
+      daemon is stopped or we run out of memory, whichever happens earlier.
+      Use GetJSONData() on individual devices to retrieve the data from the
+      daemon.
+
+      When drawings become available from a device, the DrawingsAvailable
+      property on the device updates to the number of available drawings.
+
+      Calling Listen() before a previous call has completed is silently
+      ignored and does not reset the timeout.
+
+      Returns: 0 on success or a negative errno on failure
 
 org.freedesktop.tuhi1.Device
 
@@ -59,37 +88,6 @@ org.freedesktop.tuhi1.Device
       An integer indicating the number of drawings available. Drawings are
       zero-indexed, see GetJSONData().
       Read-only
-
-  Property: Listening (b)
-      Indicates whether the daemon is currently listening for the device.
-
-      This property is set to True when a Listen() request initiates the
-      search for device connections. When the Listen() request completes
-      upon timeout, the property is set to False.
-      Read-only
-
-  Method: Listen() -> ()
-      Listen for data from this device. This method starts listening for
-      events on the device for an unspecified timeout. When the timeout
-      expires, a ListenComplete signal is sent indicating success or error.
-
-      This function requires the device to be connected and may require some
-      interactivity (e.g. the user may need to press the sync button).
-
-      When the device connects, the daemon downloads all drawings from the
-      device. If successfull, the drawings are deleted from the device. The
-      data is held by the daemon in non-persistent storage until the daemon
-      is stopped or we run out of memory, whichever happens earlier.  Use
-      GetJSONData() to retrieve the data from the daemon.
-
-      When drawings become available from the device, the DrawingsAvailable
-      property updates to the number of available drawings.
-
-      When this function is called multiple times, any new data is appended
-      to the existing list of drawings. Calling Listen() before a previous
-      call has completed is silently ignored and does not reset the timeout.
-
-      Returns: 0 on success or a negative errno on failure
 
   Method: GetJSONData(index: u) -> (s)
       Returns a JSON file with the drawings specified by the index argument.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ org.freedesktop.tuhi1.Manager
       expires, a ListenComplete signal is sent indicating success or error.
 
       When a compatible device appears (button pressed), the daemon connects
-      to it and downloads all drawings from the device.
+      to it, downloads all drawings from the device and disconnects itself.
       If successfull, the drawings are deleted from the device.
       The data is held by the daemon in non-persistent storage until the
       daemon is stopped or we run out of memory, whichever happens earlier.

--- a/tuhi.py
+++ b/tuhi.py
@@ -142,13 +142,13 @@ class Tuhi(GObject.Object):
             (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
     }
 
-    def __init__(self, debug):
+    def __init__(self, debug_mode=False):
         GObject.Object.__init__(self)
         self.server = TuhiDBusServer()
         self.server.connect('bus-name-acquired', self._on_tuhi_bus_name_acquired)
         self.bluez = BlueZDeviceManager()
         self.bluez.connect('device-updated', self._on_bluez_device_updated)
-        self.always_listening = debug
+        self.always_listening = debug_mode
 
         self.server.start()
 
@@ -192,7 +192,7 @@ def main(args):
         for l in [logger, ble_logger, wacom_logger, dbusserver_logger]:
             l.setLevel(logging.DEBUG)
 
-    Tuhi(ns.debug)
+    Tuhi(debug_mode=ns.debug)
     try:
         GObject.MainLoop().run()
     except KeyboardInterrupt:

--- a/tuhi.py
+++ b/tuhi.py
@@ -78,6 +78,7 @@ class TuhiDevice(GObject.Object):
         self._tuhi_dbus_device = tuhi_dbus_device
         self._wacom_device = WacomDevice(bluez_device)
         self._wacom_device.connect('drawing', self._on_drawing_received)
+        self._wacom_device.connect('done', self._on_fetching_finished)
         self.drawings = []
 
         bluez_device.connect('connected', self._on_bluez_device_connected)
@@ -123,6 +124,9 @@ class TuhiDevice(GObject.Object):
             d.strokes.append(stroke)
 
         self._tuhi_dbus_device.add_drawing(d)
+
+    def _on_fetching_finished(self, device):
+        self._bluez_device.disconnect_device()
 
 
 class Tuhi(GObject.Object):

--- a/tuhi.py
+++ b/tuhi.py
@@ -139,10 +139,12 @@ class Tuhi(GObject.Object):
         self.bluez = BlueZDeviceManager()
         self.bluez.connect('device-added', self._on_bluez_device_added)
 
+        self.server.start()
+
         self.devices = {}
 
     def _on_tuhi_bus_name_acquired(self, dbus_server):
-        self.bluez.connect_to_bluez()
+        self.server.bluez = self.bluez
 
     def _on_bluez_device_added(self, manager, bluez_device):
         if bluez_device.vendor_id != WACOM_COMPANY_ID:

--- a/tuhi.py
+++ b/tuhi.py
@@ -142,7 +142,6 @@ class Tuhi(GObject.Object):
         self.server = TuhiDBusServer()
         self.server.connect('bus-name-acquired', self._on_tuhi_bus_name_acquired)
         self.bluez = BlueZDeviceManager()
-        self.bluez.connect('device-added', self._on_bluez_device_added)
         self.bluez.connect('device-updated', self._on_bluez_device_updated)
 
         self.server.start()
@@ -159,12 +158,6 @@ class Tuhi(GObject.Object):
             self.devices[bluez_device.address] = d
 
         return self.devices[bluez_device.address]
-
-    def _on_bluez_device_added(self, manager, bluez_device):
-        if bluez_device.vendor_id != WACOM_COMPANY_ID:
-            return
-
-        self.get_tuhi_device(bluez_device).retrieve_data()
 
     def _on_bluez_device_updated(self, manager, bluez_device):
         if bluez_device.vendor_id != WACOM_COMPANY_ID:

--- a/tuhi.py
+++ b/tuhi.py
@@ -148,6 +148,7 @@ class Tuhi(GObject.Object):
         self.server.connect('bus-name-acquired', self._on_tuhi_bus_name_acquired)
         self.bluez = BlueZDeviceManager()
         self.bluez.connect('device-updated', self._on_bluez_device_updated)
+        self.bluez.connect('listening-timer-expired', self._on_listening_timer_expired)
         self.always_listening = debug_mode
 
         self.server.start()
@@ -158,7 +159,14 @@ class Tuhi(GObject.Object):
         self.server.bluez = self.bluez
 
         if self.always_listening:
-            self.server._listen()
+            # the device advertises for 5 seconds, using two times as the timeout
+            self.server._listen(10)
+
+    def _on_listening_timer_expired(self, bluez):
+        self.server._stop_listening()
+
+        if self.always_listening:
+            self.server._listen(10)
 
     def get_tuhi_device(self, bluez_device):
         if bluez_device.address not in self.devices:

--- a/tuhi.py
+++ b/tuhi.py
@@ -89,7 +89,8 @@ class TuhiDevice(GObject.Object):
 
     def _on_bluez_device_connected(self, bluez_device):
         logger.debug('{}: connected'.format(bluez_device.address))
-        self._wacom_device.start()
+        if not self._wacom_device.working:
+            self._wacom_device.start()
 
     def _on_bluez_device_disconnected(self, bluez_device):
         logger.debug('{}: disconnected'.format(bluez_device.address))

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -13,7 +13,6 @@
 import logging
 from gi.repository import GObject, Gio
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger('ble')
 
 ORG_BLUEZ_GATTCHARACTERISTIC1 = 'org.bluez.GattCharacteristic1'

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -230,8 +230,10 @@ class BlueZDevice(GObject.Object):
             if properties['ServicesResolved']:
                 self.emit('connected')
         else:
-            # FIXME: should we only match on 'RSSI' and 'ManufacturerData'?
-            self.emit('updated')
+            # if RSSI is invalidated, it means the discovery ended
+            if 'RSSI' not in invalidated_properties:
+                # FIXME: should we only match on 'RSSI' and 'ManufacturerData'?
+                self.emit('updated')
 
     def connect_gatt_value(self, uuid, callback):
         """

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -115,7 +115,8 @@ class BlueZDevice(GObject.Object):
         self.characteristics = {}
         self.resolve(om)
         self.interface.connect('g-properties-changed', self._on_properties_changed)
-        if self.interface.get_cached_property('Connected').get_boolean() and self.interface.get_cached_property('ServicesResolved').get_boolean():
+        if (self.interface.get_cached_property('Connected').get_boolean() and
+                self.interface.get_cached_property('ServicesResolved').get_boolean()):
             self.emit('connected')
 
     @property
@@ -186,7 +187,8 @@ class BlueZDevice(GObject.Object):
         asynchronous and returns immediately.
         """
         i = self.obj.get_interface(ORG_BLUEZ_DEVICE1)
-        if i.get_cached_property('Connected').get_boolean() and i.get_cached_property('ServicesResolved').get_boolean():
+        if (i.get_cached_property('Connected').get_boolean() and
+                i.get_cached_property('ServicesResolved').get_boolean()):
             logger.info('{}: Device is already connected'.format(self.address))
             self.emit('connected')
             return

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -199,6 +199,24 @@ class BlueZDevice(GObject.Object):
         if isinstance(result, Exception):
             logger.error('Connection failed: {}'.format(result))
 
+    def disconnect_device(self):
+        """
+        Disconnect to the bluetooth device via bluez. This function is
+        asynchronous and returns immediately.
+        """
+        i = self.obj.get_interface(ORG_BLUEZ_DEVICE1)
+        if not i.get_cached_property('Connected').get_boolean():
+            logger.info('{}: Device is already disconnected'.format(self.address))
+            self.emit('disconnected')
+            return
+
+        logger.info('{}: Disconnecting'.format(self.address))
+        i.Disconnect(result_handler=self._on_disconnect_result)
+
+    def _on_disconnect_result(self, obj, result, user_data):
+        if isinstance(result, Exception):
+            logger.error('Disconnection failed: {}'.format(result))
+
     def _on_properties_changed(self, obj, properties, invalidated_properties):
         properties = properties.unpack()
 

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -239,6 +239,7 @@ class BlueZDeviceManager(GObject.Object):
     def __init__(self, **kwargs):
         GObject.Object.__init__(self, **kwargs)
         self.devices = []
+        self.adapters = []
 
     def connect_to_bluez(self):
         """
@@ -281,6 +282,9 @@ class BlueZDeviceManager(GObject.Object):
         objpath = obj.get_object_path()
         logger.debug('Object removed: {}'.format(objpath))
 
+        if obj.get_interface(ORG_BLUEZ_ADAPTER1) is not None:
+            self.adapters.remove(obj)
+
     def _process_object(self, obj):
         """Process a single DBusProxyObject"""
 
@@ -296,7 +300,15 @@ class BlueZDeviceManager(GObject.Object):
     def _process_adapter(self, obj):
         objpath = obj.get_object_path()
         logger.debug('Adapter: {}'.format(objpath))
-        # FIXME: call StartDiscovery if we want to pair
+        self.adapters.append(obj)
+
+    def listen(self):
+        """Start Discovery"""
+        for a in self.adapters:
+            objpath = a.get_object_path()
+            logger.debug('Listening on: {}'.format(objpath))
+            i = a.get_interface(ORG_BLUEZ_ADAPTER1)
+            i.StartDiscovery()
 
     def _process_device(self, obj):
         dev = BlueZDevice(self._om, obj)

--- a/tuhi/ble.py
+++ b/tuhi/ble.py
@@ -114,8 +114,7 @@ class BlueZDevice(GObject.Object):
         self.characteristics = {}
         self.resolve(om)
         self.interface.connect('g-properties-changed', self._on_properties_changed)
-        # FIXME: this should switch to ServicesResolved
-        if self.interface.get_cached_property('Connected').get_boolean():
+        if self.interface.get_cached_property('Connected').get_boolean() and self.interface.get_cached_property('ServicesResolved').get_boolean():
             self.emit('connected')
 
     @property
@@ -186,9 +185,8 @@ class BlueZDevice(GObject.Object):
         asynchronous and returns immediately.
         """
         i = self.obj.get_interface(ORG_BLUEZ_DEVICE1)
-        if i.get_cached_property('Connected').get_boolean():
+        if i.get_cached_property('Connected').get_boolean() and i.get_cached_property('ServicesResolved').get_boolean():
             logger.info('{}: Device is already connected'.format(self.address))
-            # FIXME: this should switch to ServicesResolved
             self.emit('connected')
             return
 
@@ -205,10 +203,12 @@ class BlueZDevice(GObject.Object):
         if 'Connected' in properties:
             if properties['Connected']:
                 logger.info('Connection established')
-                self.emit('connected')
             else:
                 logger.info('Disconnected')
                 self.emit('disconnected')
+        elif 'ServicesResolved' in properties:
+            if properties['ServicesResolved']:
+                self.emit('connected')
 
     def connect_gatt_value(self, uuid, callback):
         """

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -164,6 +164,7 @@ class TuhiDBusServer(GObject.Object):
 
         if methodname == 'Listen':
             self._listen()
+            invocation.return_value()
 
     def _property_read_cb(self, connection, sender, objpath, interface, propname):
         if interface != INTF_MANAGER:

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -15,7 +15,6 @@ import logging
 
 from gi.repository import GObject, Gio, GLib
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger('dbus')
 
 INTROSPECTION_XML = """

--- a/tuhi/dbusserver.py
+++ b/tuhi/dbusserver.py
@@ -136,6 +136,10 @@ class TuhiDBusServer(GObject.Object):
     def __init__(self):
         GObject.Object.__init__(self)
         self._devices = []
+        self._bluez = None
+
+    def start(self):
+        """Starts the DBus server."""
         self._dbus = Gio.bus_own_name(Gio.BusType.SESSION,
                                       BUS_NAME,
                                       Gio.BusNameOwnerFlags.NONE,
@@ -175,6 +179,15 @@ class TuhiDBusServer(GObject.Object):
 
     def _property_write_cb(self):
         pass
+
+    @property
+    def bluez(self):
+        return self._bluez
+
+    @bluez.setter
+    def bluez(self, bluez):
+        self._bluez = bluez
+        self._bluez.connect_to_bluez()
 
     def cleanup(self):
         Gio.bus_unown_name(self._dbus)

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -134,6 +134,8 @@ class WacomDevice(GObject.Object):
         self.height = WACOM_SLATE_HEIGHT
         self.name = device.name
 
+        self.working = False
+
         device.connect_gatt_value(WACOM_CHRC_LIVE_PEN_DATA_UUID,
                                   self._on_pen_data_changed)
         device.connect_gatt_value(WACOM_OFFLINE_CHRC_PEN_DATA_UUID,
@@ -570,7 +572,11 @@ class WacomDevice(GObject.Object):
 
     def run(self):
         logger.debug('{}: starting'.format(self.device.address))
-        self.retrieve_data()
+        self.working = True
+        try:
+            self.retrieve_data()
+        finally:
+            self.working = False
 
     def start(self):
         self.thread = threading.Thread(target=self.run)

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -121,6 +121,8 @@ class WacomDevice(GObject.Object):
     __gsignals__ = {
         "drawing":
             (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+        "done":
+            (GObject.SIGNAL_RUN_FIRST, None, ()),
     }
 
     def __init__(self, device):
@@ -577,6 +579,7 @@ class WacomDevice(GObject.Object):
             self.retrieve_data()
         finally:
             self.working = False
+            self.emit("done")
 
     def start(self):
         self.thread = threading.Thread(target=self.run)

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -151,7 +151,7 @@ class WacomDevice(GObject.Object):
         logger.debug(binascii.hexlify(bytes(value)))
 
         if value[0] == 0x10:
-            pressure = int.from_bytes(value[2:4], byteorder='big')
+            pressure = int.from_bytes(value[2:4], byteorder='little')
             buttons = int(value[10])
             logger.info(f'New Pen Data: pressure: {pressure}, button: {buttons}')
         elif value[0] == 0xa2:
@@ -170,9 +170,9 @@ class WacomDevice(GObject.Object):
                 if bytes(data) == b'\xff\xff\xff\xff\xff\xff':
                     logger.info(f'Pen left proximity')
                 else:
-                    x = int.from_bytes(data[0:2], byteorder='big')
-                    y = int.from_bytes(data[2:4], byteorder='big')
-                    pressure = int.from_bytes(data[4:6], byteorder='big')
+                    x = int.from_bytes(data[0:2], byteorder='little')
+                    y = int.from_bytes(data[2:4], byteorder='little')
+                    pressure = int.from_bytes(data[4:6], byteorder='little')
                     if self.orientation == ORIENTATION_PORTRAIT:
                         t = x
                         x = self.height - y
@@ -318,7 +318,7 @@ class WacomDevice(GObject.Object):
         if len(data) != 6:
             str_data = binascii.hexlify(bytes(data))
             raise WacomCorruptDataException(f'unexpected answer for get_dimensions: {str_data}')
-        return int.from_bytes(data[2:4], byteorder='big')
+        return int.from_bytes(data[2:4], byteorder='little')
 
     def ec_command(self):
         args = [0x06, 0x00, 0x00, 0x00, 0x00, 0x00]
@@ -347,9 +347,9 @@ class WacomDevice(GObject.Object):
                                              expected_opcode=0xc2)
         n = 0
         if self.is_slate():
-            n = int.from_bytes(data[0:2], byteorder='big')
-        else:
             n = int.from_bytes(data[0:2], byteorder='little')
+        else:
+            n = int.from_bytes(data[0:2], byteorder='big')
         logger.debug(f'Drawings available: {n}')
         return n > 0
 
@@ -357,7 +357,7 @@ class WacomDevice(GObject.Object):
         data = self.send_nordic_command_sync(command=0xcc,
                                              expected_opcode=0xcf)
         # logger.debug(f'cc returned {data} ')
-        count = int.from_bytes(data[0:4], byteorder='big')
+        count = int.from_bytes(data[0:4], byteorder='little')
         str_timestamp = ''.join([hex(d)[2:] for d in data[4:]])
         timestamp = time.strptime(str_timestamp, "%y%m%d%H%M%S")
         return count, timestamp
@@ -369,7 +369,7 @@ class WacomDevice(GObject.Object):
         # the btsnoop logs but I only rarely get a c7 response here
         count = 0
         if data.opcode == 0xc7:
-            count = int.from_bytes(data[0:4], byteorder='big')
+            count = int.from_bytes(data[0:4], byteorder='little')
             data = self.wait_nordic_data(0xcd, 5)
             # logger.debug(f'cc returned {data} ')
 
@@ -456,7 +456,7 @@ class WacomDevice(GObject.Object):
         full_coord_bitmask = 0b11 << (2 * n)
         delta_coord_bitmask = 0b10 << (2 * n)
         if (bitmask & full_coord_bitmask) == full_coord_bitmask:
-            v = int.from_bytes(data[2 * n:2 * n + 2], byteorder='big')
+            v = int.from_bytes(data[2 * n:2 * n + 2], byteorder='little')
             dv = 0
         elif bitmask & delta_coord_bitmask:
             dv += signed_char_to_int(data[2 * n + 1])

--- a/tuhi/wacom.py
+++ b/tuhi/wacom.py
@@ -18,7 +18,6 @@ import threading
 import time
 from gi.repository import GObject
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger('wacom')
 
 WACOM_COMPANY_ID = 0x4755


### PR DESCRIPTION
With this PR, the client can call Listen() on the manager, and every time the device attempts to connect to the host, the daemon will retrieve the data out of it.

Things that will require further work:
- only use paired devices?
- override DiscoverableTimeout to have a timeout handled by bluez
- pairing mode (not automatically retrieve the device info, but pair to it)
- generate and store a UUID for every device we know of using gsettings